### PR TITLE
Kernel scalarize

### DIFF
--- a/nussl/separation/duet.py
+++ b/nussl/separation/duet.py
@@ -331,7 +331,7 @@ class Duet(mask_separation_base.MaskSeparationBase):
         # check the dimensions of the Kernel matrix and set the values of the averaging
         # matrix, kernel_matrix
         if np.prod(kernel.shape) == 1:
-            kernel_matrix = np.ones((kernel, kernel)) / kernel ** 2
+            kernel_matrix = np.ones((kernel[0], kernel[0])) / kernel[0] ** 2
         else:
             kernel_matrix = kernel
 


### PR DESCRIPTION
Discovered bug when running demo_duet.py on refactorization

error message:
```
Traceback (most recent call last):
  File "demo_duet.py", line 33, in <module>
    main()
  File "demo_duet.py", line 19, in main
    duet.run()
  File "/Users/june/miniconda2/envs/new_nussl_env/lib/python2.7/site-packages/nussl/separation/duet.py", line 163, in run
    self.normalized_attenuation_delay_histogram, self.attenuation_bins, self.delay_bins = self._make_histogram()
  File "/Users/june/miniconda2/envs/new_nussl_env/lib/python2.7/site-packages/nussl/separation/duet.py", line 258, in _make_histogram
    histogram = self._smooth_matrix(histogram, np.array([3]))
  File "/Users/june/miniconda2/envs/new_nussl_env/lib/python2.7/site-packages/nussl/separation/duet.py", line 337, in _smooth_matrix
    kernel_matrix = np.ones((kernel, kernel)) / kernel ** 2
  File "/Users/june/miniconda2/envs/new_nussl_env/lib/python2.7/site-packages/numpy/core/numeric.py", line 192, in ones
    a = empty(shape, dtype, order)
TypeError: only integer scalar arrays can be converted to a scalar index
```

Quick fix: access the only array element, see diff.
