### PR TITLE
Add flag to resume training

### DIFF
--- a/bin/nussl-train
+++ b/bin/nussl-train
@@ -40,11 +40,18 @@ def parse():
         type=bool,
         help='Whether to log loss and other metrics to tensorboard file, defaults to True',
     )
+
+    parser.add_argument(
+        '--resume',
+        default=False,
+        type=bool,
+        help="Whether to resume from a previous run.",
+    )
     
     return parser.parse_args()
 
 
-def train(output_folder, model, dataset, train, use_tensorboard=True):
+def train(output_folder, model, dataset, train, use_tensorboard=True, resume=False):
     cpu_count = multiprocessing.cpu_count()
     train['num_workers'] = min(cpu_count, train['num_workers'])
 
@@ -72,6 +79,8 @@ def train(output_folder, model, dataset, train, use_tensorboard=True):
         ),
         use_tensorboard=use_tensorboard,
     )
+    if resume:
+        trainer.resume()
     trainer.fit()
 
 if __name__ == "__main__":
@@ -83,4 +92,5 @@ if __name__ == "__main__":
     }
     jsons['output_folder'] = parsed['output_folder']
     jsons['use_tensorboard'] = parsed['use_tensorboard']
+    jsons['resume'] = parsed['resume']
     train(**jsons)

--- a/nussl/deep/train/trainer.py
+++ b/nussl/deep/train/trainer.py
@@ -289,8 +289,6 @@ class Trainer():
         optimizer_state = torch.load(optimizer_path)
 
         model_dict = torch.load(model_path, map_location=lambda storage, loc: storage)
-        model = model_dict['model']
-        model.load_state_dict(model_dict['state_dict'])
+        self.module.load_state_dict(model_dict['state_dict'])
 
-        self.model = self.load_model(model_path)
         return


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/interactiveaudiolab/nussl/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.
Adds the ability to resume training from the latest checkpoint.

#### Any other comments?
This is just a change I made in my branch which I thought might be appreciated upstream.

I'm not sure whether my changes to `resume()` are correct but they seem to work (it seems like there's a mismatch between what it expected to be saved and what was).

Also, I don't think the epoch number is handled correctly so the tensorboard might be overwritten with the new epoch numbers, but I don't know how to fix that.